### PR TITLE
개츠비 경고 문구 해결, 웹폰트 공통으로 분류

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -29,3 +29,15 @@ exports.createPages = async function ({ actions, graphql }) {
     })
   })
 }
+
+exports.onCreateWebpackConfig = ({ stage, actions }) => {
+  if (stage.startsWith("develop")) {
+    actions.setWebpackConfig({
+      resolve: {
+        alias: {
+          "react-dom": "@hot-loader/react-dom",
+        },
+      },
+    })
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,11 +20,12 @@
     "prismjs": "^1.20.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
-    "react-dom": "npm:@hot-loader/react-dom",
+    "react-dom": "^16.12.0",
     "react-helmet": "^6.1.0",
     "styled-components": "^5.1.1"
   },
   "devDependencies": {
+    "@hot-loader/react-dom": "^16.13.0",
     "prettier": "2.0.5"
   },
   "keywords": [

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -24,12 +24,10 @@ Header.defaultProps = {
 export default Header
 
 const StyledHeader = styled.header`
-  @import url("https://fonts.googleapis.com/css2?family=Sulphur+Point:wght@700&display=swap");
-
   position: sticky;
   top: 0;
   padding: 24px 0;
-  font-size: 2rem;
+  font-size: 1.4rem;
   font-weight: bold;
   font-family: "Sulphur Point", sans-serif;
   text-align: center;

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -2,9 +2,9 @@ import React from "react"
 import PropTypes from "prop-types"
 import { useStaticQuery, graphql } from "gatsby"
 import styled from "styled-components"
-import { rgba } from "polished"
 
 import GlobalStyle from "../styles/global"
+import Helmet from "react-helmet"
 import Header from "./header"
 import Footer from "./footer"
 
@@ -22,6 +22,25 @@ const Layout = ({ children }) => {
   return (
     <Frame>
       <GlobalStyle />
+      <Helmet
+        link={[
+          {
+            href:
+              "https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap",
+            rel: "stylesheet",
+          },
+          {
+            href:
+              "https://fonts.googleapis.com/css2?family=Sulphur+Point:wght@700&display=swap",
+            rel: "stylesheet",
+          },
+          {
+            href:
+              "https://fonts.googleapis.com/css2?family=Fira+Code:wght@500&display=swap",
+            rel: "stylesheet",
+          },
+        ]}
+      />
       <Header title={data.site.siteMetadata.title} />
       <Page>{children}</Page>
       <Footer />
@@ -41,15 +60,12 @@ const Frame = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: #d7dae8;
   min-height: 100vh;
 `
 
 const Page = styled.main`
   position: relative;
+  width: 100%;
+  max-width: 640px;
   max-height: 100%;
-  background: #fff;
-  box-shadow: 15px 30px 60px rgba(0, 0, 0, 0.2);
-  border: 1px solid ${rgba("#d7dae8", 0.2)};
-  border-radius: 12px;
 `

--- a/src/components/posts.js
+++ b/src/components/posts.js
@@ -10,7 +10,7 @@ function Posts() {
         edges {
           node {
             id
-            excerpt(pruneLength: 30)
+            excerpt(pruneLength: 60)
             frontmatter {
               title
               date(fromNow: true, locale: "ko")
@@ -54,7 +54,18 @@ const List = styled.ul`
 `
 
 const Item = styled.li`
+  margin: 32px 0;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 15px 30px 60px rgba(0, 0, 0, 0.2);
   line-height: 1.6;
+  overflow: hidden;
+  :first-of-type {
+    margin-top: 0;
+  }
+  :last-of-type {
+    margin-bottom: 0;
+  }
   strong {
     font-size: 140%;
   }

--- a/src/styles/global.js
+++ b/src/styles/global.js
@@ -9,7 +9,8 @@ const GlobalStyle = createGlobalStyle`
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+    font-family:  -apple-system, BlinkMacSystemFont, Segoe UI, 'Noto Sans KR', Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+    background: #d7dae8;
   }
 
   *,

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -2,10 +2,12 @@ import React from "react"
 import { graphql } from "gatsby"
 import styled from "styled-components"
 import Layout from "../components/layout"
+import SEO from "../components/seo"
 
 export default function BlogPost({ data }) {
   return (
     <Layout>
+      <SEO title={data.markdownRemark.frontmatter.title} />
       <Post dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }} />
     </Layout>
   )

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -23,7 +23,10 @@ export const query = graphql`
 `
 
 const Post = styled.article`
-  @import url("https://fonts.googleapis.com/css2?family=Fira+Code:wght@500&display=swap");
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 15px 30px 60px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
 
   pre {
     font-size: 86%;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1048,6 +1048,16 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
+"@hot-loader/react-dom@^16.13.0":
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.13.0.tgz#de245b42358110baf80aaf47a0592153d4047997"
+  integrity sha512-lJZrmkucz2MrQJTQtJobx5MICXcfQvKihszqv655p557HPi0hMOWxrNpiHv3DWD8ugNWjtWcVWqRnFvwsHq1mQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.0"
+
 "@jest/types@^25.5.0":
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
@@ -10973,15 +10983,15 @@ react-dev-utils@^4.2.3:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-"react-dom@npm:@hot-loader/react-dom":
-  version "16.13.0"
-  resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.13.0.tgz#de245b42358110baf80aaf47a0592153d4047997"
-  integrity sha512-lJZrmkucz2MrQJTQtJobx5MICXcfQvKihszqv655p557HPi0hMOWxrNpiHv3DWD8ugNWjtWcVWqRnFvwsHq1mQ==
+react-dom@^16.12.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
+  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.19.0"
+    scheduler "^0.19.1"
 
 react-error-overlay@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## react-🔥-dom patch is not detected

gatsby 콘솔로그에서 경고로 표시된 문구였다. 파일을 수정하면 `webpack-dev-server` 가 브라우저를 새로고침하지 않고 변경한 내용을 즉시 반영 해주는역할을 하는데 react-dom 과 버전이 일치하지 않아 생기지 않는 현상으로 추측하였다. 이 문제를 해결하기 위해 `gatsby-node.js` 파일에서 웹팩 설정을 생성하는 타이밍에 `react-dom` 이라는 alias를 `@hot-loader/react-dom` 을 추가 하였다.

[링크 참고](https://github.com/gaearon/react-hot-loader/issues/1227)

## 웹폰트 공통 분류

컴포넌트에 필요한 웹폰트를 `@import url(...)` 하는 방향으로 진행하고 싶었다. 하지만, 이 방법은 컴포넌트가 마운트되고 렌더링을 할 떄마다 웹폰트를 로딩하려고 시도하기 때문에 이는 웹폰트 로딩 최적화에 적절치 않는 방법으로 판단하여 `react-helmet` 을 이용하여 웹폰트를 가장 먼저 로딩하도록 작업하였다.

여기서 추가로 고민되는 문제가 발생했다. 페이지마다 `<layout />` 컴포넌트를 쓰고 있어서 다른 페이지로 이동하면 `<layout />` 컴포넌트 또한 다시 렌더링 되기 때문이다. 컴포넌트가 빈번하게 마운트되는 상황에서는 웹폰트를 어느 타이밍에 로딩해야할지 고민해봤다.

최초 렌더링을 할 때 웹폰트를 불러오려는 타이밍을 검색해본 결과 **gatsby browser api** 를 참고하여 웹폰트를 최초에 한번씩 불러오도록 작업을 해야겠다고 생각했다.