### PR TITLE
이력서 링크 연결 및 리팩토링

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,6 +5,7 @@ module.exports = {
     author: `@e2goon`,
   },
   plugins: [
+    `gatsby-alias-imports`,
     `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-source-filesystem`,

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "andromeda": "EliverLara/Andromeda",
     "gatsby": "^2.24.2",
+    "gatsby-alias-imports": "^1.0.4",
     "gatsby-image": "^2.4.13",
     "gatsby-plugin-manifest": "^2.4.18",
     "gatsby-plugin-offline": "^3.2.17",

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -2,6 +2,7 @@ import React from "react"
 import { useStaticQuery, graphql, Link } from "gatsby"
 import Image from "gatsby-image"
 import styled from "styled-components"
+import { rgba } from "polished"
 
 function Header() {
   const data = useStaticQuery(graphql`
@@ -22,10 +23,31 @@ function Header() {
   `)
   return (
     <StyledHeader>
-      <h1>
+      <Title>
         <Link to="/">{data.site.siteMetadata.title}</Link>
-      </h1>
-      <Avatar fluid={data.profile.childImageSharp.fluid} alt="내 사진" />
+      </Title>
+      <AvatarLink to="/resume">
+        <Tooltip>
+          <Icon>
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              data-prefix="fas"
+              data-icon="file"
+              role="img"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 384 512"
+            >
+              <path
+                fill="currentColor"
+                d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+              ></path>
+            </svg>
+          </Icon>
+          <span>이력서</span>
+        </Tooltip>
+        <Avatar fluid={data.profile.childImageSharp.fluid} alt="내 사진" />
+      </AvatarLink>
     </StyledHeader>
   )
 }
@@ -42,14 +64,8 @@ const StyledHeader = styled.header`
   display: flex;
   align-items: center;
   font-size: 1.4rem;
-  font-weight: bold;
-  font-family: "Sulphur Point", sans-serif;
   text-transform: uppercase;
   line-height: 1;
-  h1 {
-    margin: 0;
-    flex: 1;
-  }
   a {
     text-decoration: none;
     outline: none;
@@ -68,15 +84,75 @@ const StyledHeader = styled.header`
   }
 `
 
+const Title = styled.h1`
+  flex: 1;
+  margin: 0;
+  font-weight: bold;
+  font-family: "Sulphur Point", sans-serif;
+`
+
+const Icon = styled.span`
+  display: inline-flex;
+  align-items: center;
+  width: 20px;
+  height: 20px;
+  padding: 0.2rem;
+  svg {
+    width: 100%;
+    height: 100%;
+  }
+`
+
+const Tooltip = styled.div`
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.4rem;
+  font-size: 0.8rem;
+  color: #eee;
+  border-radius: 4px;
+  background: ${rgba("#000", 0.6)};
+  backdrop-filter: blur(10px);
+  white-space: nowrap;
+  ${Icon} {
+    margin-left: -0.2rem;
+  }
+  :focus,
+  :hover {
+    color: #fff;
+  }
+`
+
 const Avatar = styled(Image)`
   width: 6rem;
   height: 6rem;
   border-radius: 50%;
-  box-shadow: 8px 15px 30px rgba(0, 0, 0, 0.2);
+  box-shadow: 8px 15px 30px ${rgba("#000", 0.2)};
   overflow: hidden;
 
   @media (max-width: 768px) {
     width: 5rem;
     height: 5rem;
+  }
+`
+
+const AvatarLink = styled(Link)`
+  display: block;
+  position: relative;
+  ${Tooltip} {
+    position: absolute;
+    bottom: -10%;
+    left: 50%;
+    opacity: 0;
+    transform: translateX(-50%);
+    transition: all 0.2s ease;
+    z-index: 1;
+  }
+  :hover ${Tooltip} {
+    margin-bottom: 2px;
+    opacity: 1;
+  }
+  :hover ${Avatar} {
+    transform: translate(1px, 1px);
+    box-shadow: 8px 10px 15px ${rgba("#000", 0.2)};
   }
 `

--- a/src/pages/resume/index.js
+++ b/src/pages/resume/index.js
@@ -66,7 +66,7 @@ function ResumePage() {
           다하며 기획, 디자인, 개발업무에서 겪는 반복 문제들을 목격하면 그냥
           지나치지 않고 해결하려고 노력합니다. 현재{" "}
           <strong>제 팀에서 컴포넌트 단위로 UI를 설계하고 개발하는 일</strong>을
-          하고 있으며 기본적으로 웹접근성, 웹표준을 준수하려 애씁니다.
+          하고 있으며 기본적으로 웹접근성, 웹표준을 준수하려고 노력합니다.
         </p>
       </header>
 
@@ -515,6 +515,18 @@ function ResumePage() {
             </li>
             <li>정보처리기능사</li>
             <li>컴퓨터그래픽스 운용기능사</li>
+          </ul>
+        </Section>
+
+        <Section>
+          <h2>연락처</h2>
+          <ul>
+            <li>
+              <a href="mailto:e2goon@gmail.com">e2goon@gmail.com</a>
+            </li>
+            <li>
+              <a href="https://github.com/e2goon">https://github.com/e2goon</a>
+            </li>
           </ul>
         </Section>
       </main>

--- a/src/pages/resume/index.js
+++ b/src/pages/resume/index.js
@@ -3,8 +3,8 @@ import styled from "styled-components"
 import { useStaticQuery, graphql } from "gatsby"
 import Image from "gatsby-image"
 import { useKeenSlider } from "keen-slider/react"
-import Layout from "../layouts/single"
-import SEO from "../components/seo"
+import Layout from "layouts/single"
+import SEO from "components/seo"
 import "keen-slider/keen-slider.min.css"
 
 function ResumePage() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5825,6 +5825,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+gatsby-alias-imports@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/gatsby-alias-imports/-/gatsby-alias-imports-1.0.4.tgz#09177ad05aa24f321813e713de5fd7aa2b8ec5b1"
+  integrity sha512-6ov7Qd/cKdEaqrABlPUNDXWHGn8HJpU/TGm0/htBAi4nSfFJWq6EEw9apzWHfR8IoVwjHExlX5wD7Y4qKjMV0w==
+
 gatsby-cli@^2.12.60:
   version "2.12.60"
   resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-2.12.60.tgz#2e958fa97d778fafa327fce5e6c351f99f7c2cdd"


### PR DESCRIPTION
- 이력서 리팩토링을 위한 `/resume` 폴더 이동
- 블로그에 이력서 링크 추가 (툴팁, 아바타 링크 등)
- `src` 별칭 사용을 위한 `gatsby-alias-imports` 플러그인 설치